### PR TITLE
Add return in oak CORS middleware. Fix #2

### DIFF
--- a/oakCors.ts
+++ b/oakCors.ts
@@ -59,7 +59,7 @@ export const oakCors = <
         else {
           corsOptions.origin = origin;
 
-          new Cors({
+          return new Cors({
             corsOptions,
             requestMethod,
             getRequestHeader,


### PR DESCRIPTION
Add missing return statement that causes `oak` to not display response. Fix #2 