### PR TITLE
Fixed -- Import and Export type for deno v1.4.0

### DIFF
--- a/abcCors.ts
+++ b/abcCors.ts
@@ -1,4 +1,4 @@
-import { CorsOptions, CorsOptionsDelegate } from "./types.ts";
+import type { CorsOptions, CorsOptionsDelegate } from "./types.ts";
 import { Cors } from "./cors.ts";
 
 interface Req {

--- a/attainCors.ts
+++ b/attainCors.ts
@@ -1,4 +1,4 @@
-import { CorsOptions, CorsOptionsDelegate } from "./types.ts";
+import type { CorsOptions, CorsOptionsDelegate } from "./types.ts";
 import { Cors } from "./cors.ts";
 
 interface Req {

--- a/cors.ts
+++ b/cors.ts
@@ -1,4 +1,4 @@
-import { CorsOptions, OriginDelegate, CorsOptionsDelegate } from "./types.ts";
+import type { CorsOptions, OriginDelegate, CorsOptionsDelegate } from "./types.ts";
 
 interface DefaultCorsOptions {
   origin: string;

--- a/mithCors.ts
+++ b/mithCors.ts
@@ -1,4 +1,4 @@
-import { CorsOptions, CorsOptionsDelegate } from "./types.ts";
+import type { CorsOptions, CorsOptionsDelegate } from "./types.ts";
 import { Cors } from "./cors.ts";
 
 interface Req {

--- a/oakCors.ts
+++ b/oakCors.ts
@@ -1,4 +1,4 @@
-import { CorsOptions, CorsOptionsDelegate } from "./types.ts";
+import type { CorsOptions, CorsOptionsDelegate } from "./types.ts";
 import { Cors } from "./cors.ts";
 
 interface Req {

--- a/opineCors.ts
+++ b/opineCors.ts
@@ -1,4 +1,4 @@
-import { CorsOptions, CorsOptionsDelegate } from "./types.ts";
+import type { CorsOptions, CorsOptionsDelegate } from "./types.ts";
 import { Cors } from "./cors.ts";
 
 interface Req {


### PR DESCRIPTION
Hello sir, I am using your package in my project. But since deno is updated to v1.4.0, i can't use your package. I try to fix that with adding Import type and Export type in your package. If there is something i miss, i'm sorry. I hope you like my change and Accept it